### PR TITLE
ci: remove downloads folder from cache

### DIFF
--- a/.github/workflows/build_riscv.yml
+++ b/.github/workflows/build_riscv.yml
@@ -60,7 +60,6 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            ${{ env.DOWNLOAD_DIR }}
             ${{ env.SSTATE_DIR }}
           key: cache-${{ matrix.target_machine }}-${{ env.TARGET_VERSION }}
 
@@ -86,14 +85,14 @@ jobs:
 
       # Remove all files that hasn't been access in 10 days
       - name: Clean SState Cache
+        if: always()
         run: |
-          find ${SSTATE_DIR} -type f -mtime +10 -delete
+          test -d ${SSTATE_DIR} && find ${SSTATE_DIR} -type f -mtime +10 -delete
 
       - name: Save cache
         uses: actions/cache/save@v4
         if: always()
         with:
           path: |
-            ${{ env.DOWNLOAD_DIR }}
             ${{ env.SSTATE_DIR }}
           key: ${{ steps.ccache-restore.outputs.cache-primary-key }}

--- a/.github/workflows/build_rpi.yml
+++ b/.github/workflows/build_rpi.yml
@@ -62,7 +62,6 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            ${{ env.DOWNLOAD_DIR }}
             ${{ env.SSTATE_DIR }}
           key: cache-${{ matrix.target_machine }}-${{ env.TARGET_VERSION }}
 
@@ -87,14 +86,14 @@ jobs:
 
       # Remove all files that hasn't been access in 10 days
       - name: Clean SState Cache
+        if: always()
         run: |
-          find ${SSTATE_DIR} -type f -mtime +10 -delete
+          test -d ${SSTATE_DIR} && find ${SSTATE_DIR} -type f -mtime +10 -delete
 
       - name: Save cache
         uses: actions/cache/save@v4
         if: always()
         with:
           path: |
-            ${{ env.DOWNLOAD_DIR }}
             ${{ env.SSTATE_DIR }}
           key: ${{ steps.ccache-restore.outputs.cache-primary-key }}


### PR DESCRIPTION
Cache is too big for Github CI

```
Warning: Failed to save: Cache size of ~12492 MB (13099204040 B) is over the 10GB limit, not saving cache.
Warning: Cache save failed.
```

As we have the sstate available it's not really needed to have the download tarballs or git repository
